### PR TITLE
assert_not_equals

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ before continuing reading this documentation.
   - [*assert_fail*](#assert_fail)
   - [*assert_status_code*](#assert_status_code)
   - [*assert_equals*](#assert_equals)
+  - [*assert_not_equals*](#assert_not_equals)
 - [*fake* function](#fake-function)
   - [Using stdin](#using-stdin)
   - [Using a function](#using-a-function)
@@ -283,6 +284,30 @@ Running test_obvious_inequality_with_assert_equals... FAILURE
 a string should be another string
  expected [a string] but was [another string]
 doc:2:test_obvious_inequality_with_assert_equals()
+```
+
+## *assert_not_equals*
+
+    assert_not_equals <unexpected> <actual> [message]
+
+Asserts for inequality of the two strings *unexpected* and *actual*.
+
+```bash
+test_obvious_equality_with_assert_not_equals(){
+  assert_not_equals "a string" "a string" "a string should be different from another string"
+}
+test_obvious_inequality_with_assert_not_equals(){
+  assert_not_equals a b
+}
+
+```
+
+```output
+Running test_obvious_equality_with_assert_not_equals... FAILURE
+a string should be different from another string
+ expected different value than [a string] but was the same
+doc:2:test_obvious_equality_with_assert_not_equals()
+Running test_obvious_inequality_with_assert_not_equals... SUCCESS
 ```
 
 #*fake* function

--- a/bash_unit
+++ b/bash_unit
@@ -67,6 +67,16 @@ assert_equals() {
     fail "$message expected [$expected] but was [$actual]"
 }
 
+assert_not_equals() {
+  local unexpected=$1
+  local actual=$2
+  local message=$3
+  [[ -z $message ]] || message="$message\n"
+
+  [ "$unexpected" != "$actual" ] || \
+    fail "$message expected different value than [$unexpected] but was the same"
+}
+
 fake() {
   local command=$1
   shift

--- a/tests/test_bash_unit.sh
+++ b/tests/test_bash_unit.sh
@@ -45,6 +45,18 @@ test_assert_equals_succeed_when_equal() {
 
 #assert_equals can now be used in the following tests
 
+test_assert_not_equals_fails_when_equal() {
+  assert_fail \
+    "assert_not_equals toto toto" \
+    "assert_not_equals should fail"
+}
+
+test_assert_not_equals_succeeds_when_not_equal() {
+  assert \
+    "assert_not_equals 'toto tata' 'toto tutu'"\
+    'assert_not_equals should succeed'
+}
+
 test_fail_prints_failure_message() {
   assert_equals 'failure message' \
     "$(fail 'failure message' | line 2)" \


### PR DESCRIPTION
It is useful to have an `assert_not_equals` function because otherwise the comparison has to be manually written using `assert`.

I have run the unit tests with success.

I did not bother to get `doctoc` and just manually added the TOC entry. I tried to run `./test_doc.sh` (since there were no bash_unit test functions in that script) after copying `README.md` into the script folder, but that created many folders in `/tmp` and ran a long time until I interrupted it. Then I gave up on that, so it still has to be tested.