### PR TITLE
Fixed coloring for Mac OSX Bash

### DIFF
--- a/bash_unit
+++ b/bash_unit
@@ -16,11 +16,12 @@
 #
 #  https://github.com/pgrange/bash_unit
 
-NOCOLOR="[0m"
-RED="[91m"
-GREEN="[92m"
-YELLOW="[93m"
-BLUE="[94m"
+ESCAPE=$(printf "\033")
+NOCOLOR="${ESCAPE}[0m"
+RED="${ESCAPE}[91m"
+GREEN="${ESCAPE}[92m"
+YELLOW="${ESCAPE}[93m"
+BLUE="${ESCAPE}[94m"
 
 fail() {
   local MESSAGE=$1

--- a/bash_unit
+++ b/bash_unit
@@ -16,11 +16,11 @@
 #
 #  https://github.com/pgrange/bash_unit
 
-NOCOLOR="\e[0m"
-RED="\e[91m"
-GREEN="\e[92m"
-YELLOW="\e[93m"
-BLUE="\e[94m"
+NOCOLOR="[0m"
+RED="[91m"
+GREEN="[92m"
+YELLOW="[93m"
+BLUE="[94m"
 
 fail() {
   local MESSAGE=$1


### PR DESCRIPTION
The colors were not working in my Macbook.  Found that \e is not supported, so I updated to use printf + octal representation of escape