### PR TITLE
FIX #22 Correct install.sh to work on MacOS.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,6 @@ tarball_url=$(curl -s https://api.github.com/repos/pgrange/bash_unit/releases | 
 tmp_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir'`
 cd $tmp_dir
 curl -Ls $tarball_url | tar -xz
-find $tmp_dir -type f -name "bash_unit" | xargs cp -t $current_working_dir
+find "${tmp_dir}" -type f -name "bash_unit" -maxdepth 2 -exec cp {} "${current_working_dir}" \;
 rm -rf $tmpdir
 echo "thank you for downloading bash_unit, you can now run ./bash_unit"


### PR DESCRIPTION
cp on MacOS doesn't support the `-t` option. Rewrote call to find to use `--exec` and skip the pipe to `xargs`. Also quoted paths, because there could be spaces at any time.