### PR TITLE
Remove warning with find command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,6 @@ tarball_url=$(curl -s https://api.github.com/repos/pgrange/bash_unit/releases | 
 tmp_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir'`
 cd $tmp_dir
 curl -Ls $tarball_url | tar -xz
-find "${tmp_dir}" -type f -name "bash_unit" -maxdepth 2 -exec cp {} "${current_working_dir}" \;
+find "${tmp_dir}" -maxdepth 2 -type f -name "bash_unit" -exec cp {} "${current_working_dir}" \;
 rm -rf $tmpdir
 echo "thank you for downloading bash_unit, you can now run ./bash_unit"


### PR DESCRIPTION
Remove this warning when installing bash_unit on Fedora 25 or Centos 7:

```
find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
```