### PR TITLE
correct notify_test_* in text_format

### DIFF
--- a/bash_unit
+++ b/bash_unit
@@ -248,17 +248,17 @@ text_format() {
     echo -n "Running $test... " | color "$BLUE"
   }
   notify_test_pending() {
-    echo -n "PENDING" | pretty_warning
+    echo -n "PENDING" | pretty_warning -
     echo
   }
 
   notify_test_succeeded() {
-    echo -n "SUCCESS" | pretty_success
+    echo -n "SUCCESS" | pretty_success -
     echo
   }
   notify_test_failed() {
     local message="$2"
-    echo -n "FAILURE" | pretty_failure
+    echo -n "FAILURE" | pretty_failure -
     echo
     [[ -z $message  ]] || printf -- "$message\n"
   }


### PR DESCRIPTION
Let me start off by saying I don't know what I am doing. I am using homebrew's bash `4.4.12(1)-release` on macOS Sierra.

When I run `./bash_unit tests/test_*` I get the following:

```
Running tests in tests/test_one.sh
Running test_1... 
./bash_unit: line 187: $1: unbound variable
```

I looked around and came up with this PR. I literally spent 5 minutes working with bash_unit in my life. So, if this is terrible, wrong, or part of a ritual for summoning Cthulhu, you can close this and I will not be offended.