### PR TITLE
Resolved/ Muted shellcheck errors and warnings

### DIFF
--- a/bash_unit
+++ b/bash_unit
@@ -119,7 +119,7 @@ fake() {
   shift
   if [ $# -gt 0 ]
   then
-    eval "function $command() { export FAKE_PARAMS=\"\$@\" ; $@ ; }"
+    eval "function $command() { export FAKE_PARAMS=\"\$@\" ; $* ; }"
   else
     eval "function $command() { echo \"$(cat)\" ; }"
   fi

--- a/bash_unit
+++ b/bash_unit
@@ -79,15 +79,19 @@ _assert_expression() {
   local condition=$2
   local message=$3
   (
-    local stdout=$(mktemp)
-    local stderr=$(mktemp)
+    local stdout=
+    stdout=$(mktemp)
+    local stderr=
+    stderr=$(mktemp)
+
+    # shellcheck disable=SC2064
     trap "rm  -f \"$stdout\" \"$stderr\"" EXIT
 
     local status
     eval "($assertion)" >"$stdout" 2>"$stderr" && status=$? || status=$?
     if ! eval "$condition"
     then
-      fail "$(eval echo $message)" "$stdout" "$stderr"
+      fail "$(eval echo "$message")" "$stdout" "$stderr"
     fi
   ) || exit $?
 }
@@ -227,7 +231,7 @@ color() {
   _start_color
   if [ $# -gt 0 ]
   then
-    echo $*
+    echo "$*"
   else
     cat
   fi
@@ -238,6 +242,7 @@ is_terminal() {
   [ -t 1 ] || [[ "${FORCE_COLOR}" == true ]]
 }
 
+# shellcheck disable=SC2120
 text_format() {
   notify_suite_starting() {
     local test_file="$1"
@@ -273,6 +278,7 @@ text_format() {
   }
 }
 
+# shellcheck disable=SC2120
 tap_format() {
   notify_suite_starting() {
     local test_file="$1"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -79,6 +79,7 @@ test_fails_when_test_file_does_not_exist() {
 }
 
 test_display_usage_when_test_file_does_not_exist() {
+  # shellcheck disable=SC2069
   bash_unit_output=$($BASH_UNIT /not_exist/not_exist 2>&1 >/dev/null | line 1)
 
   assert_equals "file does not exist: /not_exist/not_exist"\
@@ -92,18 +93,21 @@ test_bash_unit_succeed_when_no_failure_even_if_no_teardown() {
 
 test_bash_unit_runs_teardown_even_in_case_of_failure() {
   #FIX https://github.com/pgrange/bash_unit/issues/10
+  # shellcheck disable=SC2069
   assert_equals "ran teardown" \
     "$($BASH_UNIT <(echo 'test_fail() { fail ; } ; teardown() { echo "ran teardown" >&2 ; }') 2>&1 >/dev/null)"
 }
 
 test_one_test_should_stop_after_first_assertion_failure() {
   #FIX https://github.com/pgrange/bash_unit/issues/10
+  # shellcheck disable=SC2069
   assert_equals "before failure" \
     "$($BASH_UNIT <(echo 'test_fail() { echo "before failure" >&2 ; fail ; echo "after failure" >&2 ; }') 2>&1 >/dev/null)"
 }
 
 test_one_test_should_stop_when_assert_fails() {
   #FIX https://github.com/pgrange/bash_unit/issues/26
+  # shellcheck disable=SC2069
   assert_equals "before failure" \
     "$($BASH_UNIT <(echo 'test_fail() { echo "before failure" >&2 ; assert false ; echo "after failure" >&2 ; }') 2>&1 >/dev/null)"
 }

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -102,20 +102,20 @@ another ok message" \
 
 test_fake_actually_fakes_the_command() {
   fake ps echo expected
-  assert_equals "expected" $(ps)
+  assert_equals "expected" "$(ps)"
 }
 
 test_fake_can_fake_inline() {
   assert_equals \
     "expected" \
-    $(fake ps echo expected ; ps)
+    "$(fake ps echo expected ; ps)"
 }
 
 test_fake_exports_faked_in_subshells() {
   fake ps echo expected
   assert_equals \
     expected \
-    $( bash -c ps )
+    "$( bash -c ps )"
 }
 
 test_fake_transmits_params_to_fake_code() {
@@ -135,7 +135,8 @@ test_fake_echo_stdin_when_no_params() {
  7818 pts/9    00:00:00 ps
 EOF
 
-  assert_equals 2 $(ps | grep pts | wc -l)
+  # shellcheck disable=SC2009
+  assert_equals 2 "$(ps | grep -c pts)"
 }
 
 if [[ "${STICK_TO_CWD}" != true ]]


### PR DESCRIPTION
I went through most of the shellcheck errors and warnings and tried to resolve them. Some are false alarms so I muted them with a special shellcheck comment.