### PR TITLE
Output "Overall result" line at the end

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -604,7 +604,7 @@ With bash, the result code of a pipeline equals the result code of the last comm
 
 An alternative may be to activate bash _pipefail_ option but this may introduce unwanted side effects. We can also simply not output anything in __ps_ so that _grep_ fails:
 
-```test
+```shell
 code() {
   ps a | grep apache
 }
@@ -626,7 +626,7 @@ bad, don't do that.
 
 Moreover, *assert_equals* output is captured by _ps_ and this just messes with the display of our test results:
 
-```output
+```shell
 	Running test_code_gives_ps_appropriate_parameters ... 
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -102,7 +102,7 @@ Running tests in tests/test_core.sh
 	Running test_fake_echo_stdin_when_no_params ... SUCCESS
 	Running test_fake_exports_faked_in_subshells ... SUCCESS
 	Running test_fake_transmits_params_to_fake_code ... SUCCESS
-Overall result: PASS
+Overall result: SUCCESS
 ```
 
 You might also want to run only specific tests, you may do so with the
@@ -128,18 +128,7 @@ Running tests in tests/test_core.sh
 	Running test_assert_status_code_succeeds ... SUCCESS
 	Running test_assert_succeeds ... SUCCESS
 	Running test_fail_fails ... SUCCESS
-Overall result: PASS
-```
-
-The "Overall result:" line at the end can be suppressed with the _-o_ option:
-
-```test
-./bash_unit -o -p test_assert_succeeds tests/test_core.sh
-```
-
-```output
-Running tests in tests/test_core.sh
-	Running test_assert_succeeds ... SUCCESS
+Overall result: SUCCESS
 ```
 
 *bash_unit* supports the http://testanything.org/[Test Anything Protocol] so you can ask for a tap formatted

--- a/README.adoc
+++ b/README.adoc
@@ -102,6 +102,7 @@ Running tests in tests/test_core.sh
 	Running test_fake_echo_stdin_when_no_params ... SUCCESS
 	Running test_fake_exports_faked_in_subshells ... SUCCESS
 	Running test_fake_transmits_params_to_fake_code ... SUCCESS
+Overall result: PASS
 ```
 
 You might also want to run only specific tests, you may do so with the
@@ -127,6 +128,18 @@ Running tests in tests/test_core.sh
 	Running test_assert_status_code_succeeds ... SUCCESS
 	Running test_assert_succeeds ... SUCCESS
 	Running test_fail_fails ... SUCCESS
+Overall result: PASS
+```
+
+The "Overall result:" line at the end can be suppressed with the _-o_ option:
+
+```test
+./bash_unit -o -p test_assert_succeeds tests/test_core.sh
+```
+
+```output
+Running tests in tests/test_core.sh
+	Running test_assert_succeeds ... SUCCESS
 ```
 
 *bash_unit* supports the http://testanything.org/[Test Anything Protocol] so you can ask for a tap formatted

--- a/bash_unit
+++ b/bash_unit
@@ -348,8 +348,9 @@ tap_format() {
 output_format=text
 test_pattern=""
 separator=""
+overall=1
 randomise=0
-while getopts "vp:f:r" option
+while getopts "vp:f:or" option
 do
   case "$option" in
     p)
@@ -358,6 +359,9 @@ do
       ;;
     f)
       output_format="${OPTARG}"
+      ;;
+    o)
+      overall=0
       ;;
     r)
       randomise=1
@@ -385,6 +389,7 @@ case "$output_format" in
     ;;
   tap)
     tap_format
+    overall=0
     ;;
   *)
     usage "unsupported output format: $output_format"
@@ -411,4 +416,18 @@ do
   )
   failure=$(( $? || failure))
 done
+
+# Show the overall result
+if ((overall))
+then
+  echo -n "Overall result: "
+  if ((failure))
+  then
+    echo -n "FAIL" | pretty_failure
+  else
+    echo -n "PASS" | pretty_success
+  fi
+  echo
+fi
+
 exit $failure

--- a/bash_unit
+++ b/bash_unit
@@ -306,6 +306,14 @@ text_format() {
   notify_stack() {
     color "$YELLOW"
   }
+  notify_suites_succeded() {
+    echo -n "Overall result: SUCCESS" | pretty_success
+    echo
+  }
+  notify_suites_failed() {
+    echo -n "Overall result: FAILURE" | pretty_failure
+    echo
+  }
 }
 
 tap_format() {
@@ -314,7 +322,7 @@ tap_format() {
     echo "# Running tests in $test_file"
   }
   notify_test_starting() {
-    echo -n
+    :
   }
   notify_test_pending() {
     local test="$1"
@@ -343,12 +351,17 @@ tap_format() {
   notify_stack() {
     "$SED" 's:^:# :' | color "$YELLOW"
   }
+  notify_suites_succeded() {
+    :
+  }
+  notify_suites_failed() {
+    :
+  }
 }
 
 output_format=text
 test_pattern=""
 separator=""
-overall=1
 randomise=0
 while getopts "vp:f:or" option
 do
@@ -359,9 +372,6 @@ do
       ;;
     f)
       output_format="${OPTARG}"
-      ;;
-    o)
-      overall=0
       ;;
     r)
       randomise=1
@@ -389,7 +399,6 @@ case "$output_format" in
     ;;
   tap)
     tap_format
-    overall=0
     ;;
   *)
     usage "unsupported output format: $output_format"
@@ -417,17 +426,11 @@ do
   failure=$(( $? || failure))
 done
 
-# Show the overall result
-if ((overall))
+if ((failure))
 then
-  echo -n "Overall result: "
-  if ((failure))
-  then
-    echo -n "FAIL" | pretty_failure
-  else
-    echo -n "PASS" | pretty_success
-  fi
-  echo
+  notify_suites_failed
+else
+  notify_suites_succeded
 fi
 
 exit $failure

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -7,7 +7,7 @@ Running tests in code
 	Running test_fails ... FAILURE
 code:2:test_fails()
 	Running test_succeed ... SUCCESS
-Overall resultcode: FAIL\
+Overall resultcode: FAILURE\
 " \
 "$(bash_unit_out_for_code << EOF
   function test_succeed() { assert true ; }
@@ -44,7 +44,7 @@ Running tests in test_file
 	Running test_one ... SUCCESS
 Running tests in test_file
 	Running test_two ... SUCCESS
-Overall result: PASS\
+Overall result: SUCCESS\
 " \
 "$bash_unit_output"
 }
@@ -60,7 +60,7 @@ test_run_only_tests_that_match_pattern() {
 Running tests in test_file
 	Running test_one ... SUCCESS
 Running tests in test_file
-Overall result: PASS" "$bash_unit_output"
+Overall result: SUCCESS" "$bash_unit_output"
 }
 
 test_do_not_run_pending_tests() {
@@ -81,7 +81,7 @@ test_pending_tests_appear_in_output() {
 Running tests in test_file
 	Running pending_should_not_run ... PENDING
 	Running todo_should_not_run ... PENDING
-Overall result: PASS" \
+Overall result: SUCCESS" \
   "$bash_unit_output"
 }
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -6,7 +6,8 @@ test_run_all_tests_even_in_case_of_failure() {
 Running tests in code
 	Running test_fails ... FAILURE
 code:2:test_fails()
-	Running test_succeed ... SUCCESS\
+	Running test_succeed ... SUCCESS
+Overall resultcode: FAIL\
 " \
 "$(bash_unit_out_for_code << EOF
   function test_succeed() { assert true ; }
@@ -42,7 +43,8 @@ test_run_all_file_parameters() {
 Running tests in test_file
 	Running test_one ... SUCCESS
 Running tests in test_file
-	Running test_two ... SUCCESS\
+	Running test_two ... SUCCESS
+Overall result: PASS\
 " \
 "$bash_unit_output"
 }
@@ -57,7 +59,8 @@ test_run_only_tests_that_match_pattern() {
   assert_equals "\
 Running tests in test_file
 	Running test_one ... SUCCESS
-Running tests in test_file" "$bash_unit_output" 
+Running tests in test_file
+Overall result: PASS" "$bash_unit_output"
 }
 
 test_do_not_run_pending_tests() {
@@ -77,7 +80,8 @@ test_pending_tests_appear_in_output() {
   assert_equals "\
 Running tests in test_file
 	Running pending_should_not_run ... PENDING
-	Running todo_should_not_run ... PENDING" \
+	Running todo_should_not_run ... PENDING
+Overall result: PASS" \
   "$bash_unit_output"
 }
 

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -251,4 +251,6 @@ mute() {
   notify_stack         () { echo -n ; }
   notify_stdout        () { echo -n ; }
   notify_stderr        () { echo -n ; }
+  notify_suites_succeded () { echo -n ; }
+  notify_suites_failed   () { echo -n ; }
 }

--- a/tests/test_doc.sh
+++ b/tests/test_doc.sh
@@ -6,7 +6,7 @@ LANG=C.UTF-8
 
 export FORCE_COLOR=false
 export STICK_TO_CWD=true
-BASH_UNIT="eval ./bash_unit"
+BASH_UNIT="eval ./bash_unit -o"
 #BASH_UNIT="eval FORCE_COLOR=false ./bash_unit"
 
 prepare_tests() {
@@ -20,10 +20,10 @@ prepare_tests() {
 
   while grep -E '^'"$TEST_PATTERN"'$' $remaining >/dev/null
   do
-    block=$(($block+1))
+    ((++block))
     run_doc_test  $remaining $swap |& sed '$a\' > $test_output$block
     doc_to_output $remaining $swap > $expected_output$block
-    eval 'function test_block_'"$block"'() {
+    eval 'function test_block_'"$(printf %02d $block)"'() {
         assert "diff -u '"$expected_output$block"' '"$test_output$block"'"
       }'
   done

--- a/tests/test_doc.sh
+++ b/tests/test_doc.sh
@@ -6,7 +6,7 @@ LANG=C.UTF-8
 
 export FORCE_COLOR=false
 export STICK_TO_CWD=true
-BASH_UNIT="eval ./bash_unit -o"
+BASH_UNIT="eval ./bash_unit"
 #BASH_UNIT="eval FORCE_COLOR=false ./bash_unit"
 
 prepare_tests() {
@@ -32,10 +32,23 @@ prepare_tests() {
 function run_doc_test() {
   local remaining="$1"
   local swap="$2"
-  $BASH_UNIT <(
-    cat "$remaining" | _next_code "$swap"
-  ) | tail -n +2 | sed -e 's:/dev/fd/[0-9]*:doc:g' 
+  $BASH_UNIT <(cat "$remaining" | _next_code "$swap") \
+  | clean_bash_unit_running_header \
+  | clean_bash_pseudo_files_name \
+  | clean_bash_unit_overall_result
   cat "$swap" > "$remaining"
+}
+
+function clean_bash_unit_running_header() {
+  tail -n +2
+}
+
+function clean_bash_pseudo_files_name() {
+  sed -e 's:/dev/fd/[0-9]*:doc:g'
+}
+
+function clean_bash_unit_overall_result() {
+  sed '$d'
 }
 
 function doc_to_output() {


### PR DESCRIPTION
Example:

```
$ ./bash_unit tests/test_tap_format
Running tests in tests/test_tap_format
/home/wolfram/src/bash_unit/tests
        Running test_assertion_message_is_tap_formatted ... SUCCESS ✓
        Running test_bash_unit_accepts_tap_format_option ... SUCCESS ✓
        Running test_bash_unit_rejects_invalid_format ... SUCCESS ✓
        Running test_multi_lines_assertion_message_is_tap_formatted ... SUCCESS ✓
        Running test_tap_format_for_failing_test_with_stdout_stderr_outputs ... SUCCESS ✓
        Running test_tap_format_for_one_failing_test ... SUCCESS ✓
        Running test_tap_format_for_one_pending_test ... SUCCESS ✓
        Running test_tap_format_for_one_succesfull_test ... SUCCESS ✓
Overall result: PASS ✓
```

So when you've got a lot of tests (more than a screenful) you don't have to scroll up or check $? to tell if any test has failed.

The "Overall result" line can be disabled with the new `-o` option. This is needed in the test suite which invokes bash_unit recursively, which would result in multiple "Overall result" lines.

Also makes a minor change to the test_doc.sh script: Test case names now have two-digit block numbers. Before, blocks would be tested in alphabetical order (1, 11, ..., 19, 2, 20, ...); now they are tested in numerical order (01, 02, ..., 09, 10, ...).