### PR TITLE
fixes #43

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,7 +170,9 @@ You may write a *teardown_suite* function that will be executed only once after 
 
 If you write code outside of any bash function, this code will be executed once at test file loading time since
 your file is a bash script and *bash_unit* sources it before running your tests. It is suggested to write a
-*setup_suite* function and avoid any code outside a bash function.
+*setup_suite* function and avoid any code outside a bash function. you must not use any bash_unit assertion
+in setup_suite or use exit in setup_suite for teardown_suite to be run.
+See https://github.com/pgrange/bash_unit/issues/43[issue 43] for more details.
 
 If you want to keep an eye on a test not yet implemented, prefix the name of the function by *todo* instead of test.
 Test to do are not executed and do not impact the global status of your test suite but are displayed in *bash_unit* output.

--- a/bash_unit
+++ b/bash_unit
@@ -144,7 +144,26 @@ stacktrace() {
 run_test_suite() {
   local failure=0
 
-  declare -F | "$GREP" ' setup_suite$' >/dev/null && setup_suite
+  if run_setup_suite
+  then
+    run_tests || failure=$?
+  else
+    failure=$?
+  fi
+  run_teardown_suite
+
+  return $failure
+}
+
+run_setup_suite() {
+  if declare -F | "$GREP" ' setup_suite$' >/dev/null
+  then
+    setup_suite
+  fi
+}
+
+run_tests() {
+  local failure=0
 
   for pending_test in $(set | "$GREP"  -E '^(pending|todo).* \(\)' | "$GREP" -E "$test_pattern" | "$SED" -e 's: .*::')
   do
@@ -164,9 +183,6 @@ run_test_suite() {
     )
     failure=$(( $? || failure))
   done
-
-  declare -F | "$GREP" ' teardown_suite$' >/dev/null && teardown_suite
-
   return $failure
 }
 
@@ -174,6 +190,13 @@ run_test() {
   set -e
   notify_test_starting "$__bash_unit_current_test__"
   "$__bash_unit_current_test__" && notify_test_succeeded "$__bash_unit_current_test__"
+}
+
+run_teardown_suite() {
+  if declare -F | "$GREP" ' teardown_suite$' >/dev/null
+  then
+    teardown_suite
+  fi
 }
 
 usage() {
@@ -364,7 +387,7 @@ for test_file in "$@"
 do
   notify_suite_starting "$test_file"
   (
-    set -e # Ensure bash_unit with exit with failure
+    set -e # Ensure bash_unit will exit with failure
            # in case of syntax error.
     if [[ "${STICK_TO_CWD}" != true ]]
     then

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -103,6 +103,17 @@ test_bash_unit_runs_teardown_even_in_case_of_failure() {
     "$($BASH_UNIT <(echo 'test_fail() { fail ; } ; teardown() { echo "ran teardown" >&2 ; }') 2>&1 >/dev/null)"
 }
 
+test_bash_unit_runs_teardown_suite_even_in_case_of_failure() {
+  assert_equals "ran teardown_suite" \
+    "$($BASH_UNIT <(echo 'test_fail() { fail ; } ; teardown_suite() { echo "ran teardown_suite" >&2 ; }') 2>&1 >/dev/null)"
+}
+
+test_bash_unit_runs_teardown_suite_even_in_case_of_failure_setup_suite() {
+  #FIX https://github.com/pgrange/bash_unit/issues/43
+  assert_equals "ran teardown_suite" \
+    "$($BASH_UNIT <(echo 'setup_suite() { return 1 ; } ; teardown_suite() { echo "ran teardown_suite" >&2 ; }') 2>&1 >/dev/null)"
+}
+
 test_one_test_should_stop_after_first_assertion_failure() {
   #FIX https://github.com/pgrange/bash_unit/issues/10
   assert_equals "before failure" \


### PR DESCRIPTION
That way could work but forbid usage of fail or any other bash_unit
assertion in the setup_suite function. Otherwise, the shell will just
exit and teardown_suite will not be executed.