### PR TITLE
Add option -r: Execute test cases in random order

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ bash_unit - bash unit testing enterprise edition framework for professionals!
 
 == Synopsis
 
-*bash_unit* [-f tap] [-p <pattern>] [test_file]
+*bash_unit* [-f tap] [-p <pattern>] [-r] [test_file]
 
 == Description
 
@@ -35,6 +35,12 @@ _(by the way, the documentation you are reading is itself tested with bash-unit)
   filters tests to run based on the given pattern.
   You can specify several patterns by repeating this option
   for each pattern.
+
+*-r*::
+  executes test cases in random order.
+  Only affects the order within a test file (files are always
+  executed in the order in which they are specified on the
+  command line).
 
 *-f* _output_format_::
   specify an alternative output format.

--- a/bash_unit
+++ b/bash_unit
@@ -30,6 +30,7 @@ CAT="$(which cat)"
 SED="$(which sed)"
 GREP="$(which grep)"
 RM="$(which rm)"
+SHUF="$(which shuf)"
 
 fail() {
   local message=${1:-}
@@ -162,6 +163,10 @@ run_setup_suite() {
   fi
 }
 
+maybe_shuffle() {
+  ((randomise)) && $SHUF || $CAT
+}
+
 run_tests() {
   local failure=0
 
@@ -172,7 +177,7 @@ run_tests() {
   done
 
 
-  for test in $(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" | "$SED" -e 's: .*::')
+  for test in $(set | "$GREP"  -E '^test.* \(\)' | "$GREP" -E "$test_pattern" | "$SED" -e 's: .*::' | maybe_shuffle)
   do
     (
       local status=0
@@ -201,10 +206,11 @@ run_teardown_suite() {
 
 usage() {
   echo "$1" >&2
-  echo "$0 [-f <output format>] [-p <pattern1>] [-p <pattern2>] ... <test_file1> <test_file2> ..." >&2
+  echo "$0 [-f <output format>] [-p <pattern1>] [-p <pattern2>] [-r] ... <test_file1> <test_file2> ..." >&2
   echo >&2
   echo "Runs tests in test files that match <pattern>s" >&2
   echo "<output format> is optional only supported value is tap" >&2
+  echo "-r to execute test cases in random order" >&2
   echo "-v to get current version information" >&2
   echo "See https://github.com/pgrange/bash_unit" >&2
   exit 1
@@ -342,7 +348,8 @@ tap_format() {
 output_format=text
 test_pattern=""
 separator=""
-while getopts "vp:f:" option
+randomise=0
+while getopts "vp:f:r" option
 do
   case "$option" in
     p)
@@ -351,6 +358,9 @@ do
       ;;
     f)
       output_format="${OPTARG}"
+      ;;
+    r)
+      randomise=1
       ;;
     v)
       echo "bash_unit $VERSION"


### PR DESCRIPTION
Test files are always executed in the order in which they are specified on the command line. If `-r` is specified, the test cases within a file are executed in random order.