### PR TITLE
doc: add brew installation notes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,6 +62,12 @@ ifndef::backend-manpage[]
 
     nix-shell -p bash_unit
 
+=== installing via link:https://brew.sh[Homebrew]
+
+*bash_unit* is available by invoking brew:
+
+    brew install bash_unit
+
 === other installation
 
 This will install *bash_unit* in your current working directory:
@@ -614,7 +620,7 @@ bad, don't do that.
 Moreover, *assert_equals* output is captured by _ps_ and this just messes with the display of our test results:
 
 ```output
-	Running test_code_gives_ps_appropriate_parameters ... 
+	Running test_code_gives_ps_appropriate_parameters ...
 ```
 
 The only correct alternative is for the fake _ps_ to write _FAKE_PARAMS_ in a file descriptor


### PR DESCRIPTION
I took the liberty of adding bash_unit to [Homebrew](https://brew.sh) - a popular package manager mainly used in the MacOS ecosystem. This PR adds a reference to it in the readme.