### PR TITLE
fix for issue #76 missing trailing space in output section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -620,7 +620,7 @@ bad, don't do that.
 Moreover, *assert_equals* output is captured by _ps_ and this just messes with the display of our test results:
 
 ```output
-	Running test_code_gives_ps_appropriate_parameters ...
+	Running test_code_gives_ps_appropriate_parameters ... 
 ```
 
 The only correct alternative is for the fake _ps_ to write _FAKE_PARAMS_ in a file descriptor


### PR DESCRIPTION
Issue is related to a training space generated by the test, which was missing in the output section in the README document.