### PR TITLE
enh: added assert_matches and assert_not_matches, fixes Issue 80

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,10 +93,14 @@ Running tests in tests/test_core.sh
 	Running test_assert_fails ... SUCCESS
 	Running test_assert_fails_fails ... SUCCESS
 	Running test_assert_fails_succeeds ... SUCCESS
+	Running test_assert_matches_fails_when_not_matching ... SUCCESS
+	Running test_assert_matches_succeed_when_matching ... SUCCESS
 	Running test_assert_no_diff_fails_when_diff ... SUCCESS
 	Running test_assert_no_diff_succeeds_when_no_diff ... SUCCESS
 	Running test_assert_not_equals_fails_when_equal ... SUCCESS
 	Running test_assert_not_equals_succeeds_when_not_equal ... SUCCESS
+	Running test_assert_not_matches_fails_when_matching ... SUCCESS
+	Running test_assert_not_matches_succeed_when_not_matching ... SUCCESS
 	Running test_assert_shows_stderr_on_failure ... SUCCESS
 	Running test_assert_shows_stdout_on_failure ... SUCCESS
 	Running test_assert_status_code_fails ... SUCCESS
@@ -129,10 +133,14 @@ Running tests in tests/test_core.sh
 	Running test_assert_fails ... SUCCESS
 	Running test_assert_fails_fails ... SUCCESS
 	Running test_assert_fails_succeeds ... SUCCESS
+	Running test_assert_matches_fails_when_not_matching ... SUCCESS
+	Running test_assert_matches_succeed_when_matching ... SUCCESS
 	Running test_assert_no_diff_fails_when_diff ... SUCCESS
 	Running test_assert_no_diff_succeeds_when_no_diff ... SUCCESS
 	Running test_assert_not_equals_fails_when_equal ... SUCCESS
 	Running test_assert_not_equals_succeeds_when_not_equal ... SUCCESS
+	Running test_assert_not_matches_fails_when_matching ... SUCCESS
+	Running test_assert_not_matches_succeed_when_not_matching ... SUCCESS
 	Running test_assert_shows_stderr_on_failure ... SUCCESS
 	Running test_assert_shows_stdout_on_failure ... SUCCESS
 	Running test_assert_status_code_fails ... SUCCESS
@@ -156,10 +164,14 @@ ok - test_assert_equals_succeed_when_equal
 ok - test_assert_fails
 ok - test_assert_fails_fails
 ok - test_assert_fails_succeeds
+ok - test_assert_matches_fails_when_not_matching
+ok - test_assert_matches_succeed_when_matching
 ok - test_assert_no_diff_fails_when_diff
 ok - test_assert_no_diff_succeeds_when_no_diff
 ok - test_assert_not_equals_fails_when_equal
 ok - test_assert_not_equals_succeeds_when_not_equal
+ok - test_assert_not_matches_fails_when_matching
+ok - test_assert_not_matches_succeed_when_not_matching
 ok - test_assert_shows_stderr_on_failure
 ok - test_assert_shows_stdout_on_failure
 ok - test_assert_status_code_fails
@@ -411,6 +423,56 @@ doc:2:test_obvious_equality_with_assert_not_equals()
 	Running test_obvious_inequality_with_assert_not_equals ... SUCCESS
 ```
 
+##############################
+=== *assert_matches*
+
+    assert_matches <expected-regex> <actual> [message]
+
+Asserts that the string _actual_ matches the regex pattern _expected-regex_.
+
+```test
+test_obvious_notmatching_with_assert_matches(){
+  assert_matches "a str.*" "another string" "'another string' should not match 'a str.*'"
+}
+test_obvious_matching_with_assert_matches(){
+  assert_matches "a[nN].t{0,1}.*r str.*" "another string"
+}
+
+```
+
+```output
+	Running test_obvious_matching_with_assert_matches ... SUCCESS
+	Running test_obvious_notmatching_with_assert_matches ... FAILURE
+'another string' should not match 'a str.*'
+ expected regex [a str.*] to match [another string]
+doc:2:test_obvious_notmatching_with_assert_matches()
+```
+
+=== *assert_not_matches*
+
+    assert_not_matches <unexpected-regex> <actual> [message]
+
+Asserts that the string _actual_ does not match the regex pattern _unexpected-regex_.
+
+```test
+test_obvious_matching_with_assert_not_matches(){
+  assert_not_matches "a str.*" "a string" "'a string' should not match 'a str.*'"
+}
+test_obvious_notmatching_with_assert_not_matches(){
+  assert_not_matches "a str.*" "another string"
+}
+
+```
+
+```output
+	Running test_obvious_matching_with_assert_not_matches ... FAILURE
+'a string' should not match 'a str.*'
+ expected regex [a str.*] should not match but matched [a string]
+doc:2:test_obvious_matching_with_assert_not_matches()
+	Running test_obvious_notmatching_with_assert_not_matches ... SUCCESS
+```
+
+##############################
 == *fake* function
 
     fake <command> [replacement code]

--- a/bash_unit
+++ b/bash_unit
@@ -133,13 +133,13 @@ assert_matches() {
 }
 
 assert_not_matches() {
-  local expected=$1
+  local unexpected=$1
   local actual=$2
   local message=${3:-}
   [[ -z $message ]] || message="$message\n"
 
-  if [[ "${actual}" =~ ${expected} ]]; then
-    fail "$message expected regex [$expected] should not match but matched [$actual]"
+  if [[ "${actual}" =~ ${unexpected} ]]; then
+    fail "$message expected regex [$unexpected] should not match but matched [$actual]"
   fi
 }
 

--- a/bash_unit
+++ b/bash_unit
@@ -121,6 +121,28 @@ assert_not_equals() {
     fail "$message expected different value than [$unexpected] but was the same"
 }
 
+assert_matches() {
+  local expected=$1
+  local actual=$2
+  local message=${3:-}
+  [[ -z $message ]] || message="$message\n"
+
+  if [[ ! "${actual}" =~ ${expected} ]]; then
+    fail "$message expected regex [$expected] to match [$actual]"
+  fi
+}
+
+assert_not_matches() {
+  local expected=$1
+  local actual=$2
+  local message=${3:-}
+  [[ -z $message ]] || message="$message\n"
+
+  if [[ "${actual}" =~ ${expected} ]]; then
+    fail "$message expected regex [$expected] should not match but matched [$actual]"
+  fi
+}
+
 assert_no_diff() {
   local expected=$1
   local actual=$2

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -45,6 +45,30 @@ test_assert_equals_succeed_when_equal() {
 
 #assert_equals can now be used in the following tests
 
+test_assert_matches_fails_when_not_matching() {
+  assert_fails \
+    "with_bash_unit_muted assert_matches to.*to tutu" \
+    "assert_matches should fail"
+}
+
+test_assert_matches_succeed_when_matching() {
+  assert \
+    "assert_matches 't.to{0,1} t[Aa].*ta$' 'toto tata'"\
+    'assert_matches should succeed'
+}
+
+test_assert_not_matches_fails_when_matching() {
+  assert_fails \
+    "with_bash_unit_muted assert_not_matches 't.to{0,1} t[Aa].*ta$' 'toto tata'" \
+    "assert_not_matches should fail"
+}
+
+test_assert_not_matches_succeed_when_not_matching() {
+  assert \
+    "assert_not_matches 'toto' 'tata'"\
+    'assert_not_matches should succeed'
+}
+
 test_assert_not_equals_fails_when_equal() {
   assert_fails \
     "with_bash_unit_muted assert_not_equals toto toto" \


### PR DESCRIPTION
@stuertz has provided a code fragment to provide an `assert_matches` assertion in the description of issue #80. There was no pull request yet, so I have included the code now into `bash_unit` and added the counterpart `assert_not_matches` as well. Tests have been added to `tests/test_core.sh` for both assertions. The documentation in `README-adoc` has been extended by the two new assertions, including the corresponding tests.

Many thanks to Jan for his initial contribution, this was a missing assertion I currently was looking for.