### PR TITLE
Qual: Fix typos, whitespace, beautysh

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -754,7 +754,7 @@ bad, don't do that.
 Moreover, *assert_equals* output is captured by _ps_ and this just messes with the display of our test results:
 
 ```shell
-	Running test_code_gives_ps_appropriate_parameters ... 
+	Running test_code_gives_ps_appropriate_parameters ...
 ```
 
 The only correct alternative is for the fake _ps_ to write _FAKE_PARAMS_ in a file descriptor
@@ -846,4 +846,3 @@ test_get_data_from_fake() {
  expected [ax] but was [a]
 doc:13:test_get_data_from_fake()
 ```
-

--- a/bash_unit
+++ b/bash_unit
@@ -92,7 +92,7 @@ _assert_expression() {
   (
     local stdout=$(mktemp)
     local stderr=$(mktemp)
-    # shellcheck disable=2064 # Use single quotes, expands now, not when signalled.
+    # shellcheck disable=2064 # Use single quotes, expands now, not when signaled.
     trap "$RM  -f \"$stdout\" \"$stderr\"" EXIT
 
     local status

--- a/getting_started/hello_i18n
+++ b/getting_started/hello_i18n
@@ -7,9 +7,9 @@ main() {
 hello() {
   case "$1" in
     fr) echo Bonjour le monde
-        ;;
-     *) echo we only speak french for the moment, sorry >&2
-        ;;
+      ;;
+    *) echo we only speak french for the moment, sorry >&2
+      ;;
   esac
 }
 

--- a/getting_started/hello_timed
+++ b/getting_started/hello_timed
@@ -8,8 +8,8 @@ if (( "$(current_hour)" < 11 ))
 then
   echo "Good morning World!"
 else if (( "$(current_hour)" > 17 ))
-then
-  echo "Good evening World!"
-else
-  echo "Hello World!"
+  then
+    echo "Good evening World!"
+  else
+    echo "Hello World!"
 fi ; fi

--- a/getting_started/tests/test_hello_i18n
+++ b/getting_started/tests/test_hello_i18n
@@ -16,4 +16,3 @@ test_can_say_hi_in_french() {
 setup_suite() {
   source ../hello_i18n
 }
-

--- a/release
+++ b/release
@@ -18,11 +18,11 @@ check_can_release() {
 
   [[ -z "$version" ]] && usage "No version specified on command line"
   echo "$version" | grep -E '^v[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null || usage "Invalid format for version: $version"
-  [ -r "$token_file" ] || usage "'$token_file' file does not exist" 
-  
+  [ -r "$token_file" ] || usage "'$token_file' file does not exist"
+
   # shellcheck disable=1090
   source "$token_file"
-  
+
   [[ -z "$user" ]]  && usage "user not found in file '$token_file'"
   [[ -z "$token" ]] && usage "token not found in file '$token_file'"
   true #avoid error on last instruction of function (see bash -e)
@@ -66,7 +66,7 @@ publish_release() {
   curl  -u "$user:$token" -XPOST https://api.github.com/repos/pgrange/bash_unit/releases -d "
 {
   \"tag_name\": \"$version\"
-}"
+  }"
 }
 
 usage() {

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -93,7 +93,7 @@ test_display_usage_when_test_file_does_not_exist() {
   bash_unit_output=$($BASH_UNIT /not_exist/not_exist 2>&1 >/dev/null | line 1)
 
   assert_equals "file does not exist: /not_exist/not_exist"\
-                "$bash_unit_output" 
+                "$bash_unit_output"
 }
 
 test_bash_unit_succeed_when_no_failure_even_if_no_teardown() {

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -14,7 +14,7 @@ test_fail_fails() {
 #fail can now be used in the following tests
 
 test_assert_fails_succeeds() {
-  (assert_fails false) || fail 'assert_fails should succeed' 
+  (assert_fails false) || fail 'assert_fails should succeed'
 }
 
 test_assert_fails_fails() {


### PR DESCRIPTION
# Qual: Fix typos, whitespace, beautysh

This makes some minor cleanups (detected by the tools setup in the pre-commit configuration) related to whitespace, typos and automatic shellscript formatting.