### PR TITLE
Calling bash-unit pre-commit hook in ci + sample setup

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,7 +32,14 @@ jobs:
         run: |
           set -o pipefail
           pre-commit gc
+          # Run default pre-commit hooks
           pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+          # Run manual pre-commit hook that runs bash_unit@rev
+          #  defined in .pre-commit-config.yaml
+          pre-commit run bash-unit --hook-stage manual -a | tee -a ${RAW_LOG}
+          # Run this version of bash_unit using it's current pre-commit-hook.yaml config
+          #   Useful for testing that the current version works
+          pre-commit try-repo . --verbose --all-files | tee -a ${RAW_LOG}
       - name: Convert Raw Log to annotations
         uses: mdeweerd/logToCheckStyle@v2024.2.3
         if: ${{ failure() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,3 +83,11 @@ repos:
         language: system
         entry: bash -c "./bash_unit tests/*"
         pass_filenames: false
+
+  - repo: https://github.com/pgrange/bash_unit
+    rev: 308c139639269b89c26911098b7739ee2400fcbd
+    hooks:
+      - id: bash-unit
+        stages: [manual]
+        always_run: true
+        verbose: true


### PR DESCRIPTION
This is an update to the pre-commit configuration so that it uses the hook proposed in this repository.

I used a specific commit has as there is/was no regular tag yet.

This alos shows a limitation of pre-commit: only changed files are provides as arguments and there is no option to automatically propose all files matching the regex.

Howevert that means that one could execute bash_unit on a test that changed automatically.
As shown in the integration setup, it's still possible to run on all files usin the '-a/--all-files' option.  The other solution is to use the 'args:' parameter in the hook configuration.