### PR TITLE
Fixes #115

### DIFF
--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -335,7 +335,7 @@ mute() {
   notify_test_succeeded() { : ; }
   notify_test_failed   () { : ; }
   notify_message       () { : ; }
-  notify_stack         () { : ; }
+  notify_stack         () { $CAT >/dev/null ; }
   notify_stdout        () { : ; }
   notify_stderr        () { : ; }
   notify_suites_succeded () { : ; }

--- a/tests/test_doc.sh
+++ b/tests/test_doc.sh
@@ -19,17 +19,12 @@ prepare_tests() {
   while grep -E "^${TEST_PATTERN}$" "$remaining" >/dev/null
   do
     ((++block))
-    run_doc_test  "$remaining" "$swap" |& sed "\$a\\" | work_around_github_action_problem > "$test_output$block"
+    run_doc_test  "$remaining" "$swap" |& sed "\$a\\" > "$test_output$block"
     doc_to_output "$remaining" "$swap" > "$expected_output$block"
     eval 'function test_block_'"$(printf "%02d" "$block")"'() {
         assert "diff -u '"$expected_output$block"' '"$test_output$block"'"
       }'
   done
-}
-
-work_around_github_action_problem() {
-  # I have no idea what is happening with these broken pipes on github actions
-  grep -v '^/usr/bin/grep: write error: Broken pipe$'
 }
 
 function run_doc_test() {


### PR DESCRIPTION
We observed broken pipe output messages with bash_unit test in some environments: github CI and nix builds. The tests are passing but display this suspiscious error message.

@Pamplemousse has been able to reproduce them locally by trapping SIGPIPE:


```bash
  # trap '' SIGPIPE
  # ./bash_unit -p test_fail_fails tests/test_core.sh
  Running tests in tests/test_core.sh
          Running test_fail_fails ... /nix/store/11b3chszacfr9liy829xqknzp3q88iji-gnugrep-3.11/bin/grep: write error: Broken pipe
  SUCCESS ✓
  Overall result: SUCCESS ✓
```

From man, SIGPIPE appears when a process writes on a pipe with no reader. Looking at the problematic tests, we see that they all rely on a muted bash_unit with a stacktrace output being muted.

When we look at how the stacktrace is muted, the code was like this:


```bash
  notify_stack () { : ; }
```

And when we look at how the stacktrace is outputed by bash_unit we see the following code:

```bash
  stacktrace | notify_stack
```

So we have some process run by stacktrace that is piped to a void function, that is, no process on the right of this pipe is reading which makes it a good candidate to generate a SIGPIPE.

By replacing the muted notify_stack with the following code, the issue is solved:


```
  notify_stack  () { $CAT >/dev/null ; }
```