### PR TITLE
Fix tarball url parsing in presence of "pipefail"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 echo "downloading bash_unit"
 current_working_dir=$PWD
-tarball_url=$(curl -s https://api.github.com/repos/pgrange/bash_unit/releases | grep tarball_url | head -n 1 | cut -d '"' -f 4)
+tarball_urls=$(curl -s https://api.github.com/repos/pgrange/bash_unit/releases | grep tarball_url)
+tarball_url=$(echo "$tarball_urls" | head -n 1 | cut -d '"' -f 4)
 tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir')
 cd "$tmp_dir" || exit
 curl -Ls "$tarball_url" | tar -xz -f -


### PR DESCRIPTION
Fixes #124 

Piping to `head` does not mix with `set -o pipefail` because `head` "short-circuits" as soon as it finds a result, causing a SIGPIPE to be sent to the writer, which may cause the writer to fail.