### PR TITLE
feat: capture code coverage in tests

### DIFF
--- a/.github/workflows/bash_unit.yml
+++ b/.github/workflows/bash_unit.yml
@@ -1,14 +1,35 @@
 name: bash_unit tests
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Unit testing with bash_unit
-      run: FORCE_COLOR=true ./bash_unit tests/test*
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: docker://kcov/kcov:latest
+        with:
+          entrypoint: sh
+          args: >-
+            -ceux
+            "cd tests && kcov
+            --bash-parse-files-in-dir=..
+            --include-pattern=bash_unit
+            --exclude-pattern=/tests/
+            ../coverage
+            ../bash_unit test*.sh"
+      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        if: ${{ !cancelled() }}
+        with:
+          use_oidc: true
+          files: ./coverage/bash_unit.*/cobertura.xml
+          disable_search: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ token
 
 # BSD sed generated files
 *-e
+
+# Coverage output
+coverage/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         args:
           - --no-warnings
           - -d
-          - '{extends: relaxed, rules: {line-length: {max: 120}}}'
+          - "{extends: relaxed, rules: {line-length: {max: 120}}}"
 
   # Execute codespell to fix typo errors (setup of codespell into dev/tools/codespell/)
   - repo: https://github.com/codespell-project/codespell
@@ -68,14 +68,14 @@ repos:
           - --ignore-words-list=master,als
           - --builtin=clear,rare,informal,usage,code,names,en-GB_to_en-US
         exclude_types: [image]
-        exclude: ^docs/man/.*$
+        exclude: ^(docs/man/|coverage/).*$
 
   # Check some shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6
     hooks:
       - id: shellcheck
-        args: [-W, '100']
+        args: [-W, "100"]
 
   # Run tests
   - repo: local


### PR DESCRIPTION
> [!Warning]
> This is a work in progress. Do not merge. 

Capture code coverage in CI and use codecov to track it.

Note: This only works on Linux due to missing functionality (ptrace/DWARF). Should be good enough for CI though.

---

### Todo

- [ ] Add Codecov (Example usage: https://github.com/jbergstroem/hadolint-gh-action)
- [ ] Investigate broken test
- [ ] Codespell